### PR TITLE
Make close button styles generic in marketplace banner

### DIFF
--- a/dist/css/marketplace-elements.css
+++ b/dist/css/marketplace-elements.css
@@ -5,9 +5,9 @@
   background: #797979;
   color: #fff;
   display: block;
+  line-height: 1.3;
   overflow: hidden;
   position: relative;
-  line-height: 1.3;
 }
 .mkt-banner-content {
   margin: 2px auto;
@@ -16,8 +16,12 @@
   text-align: center;
 }
 .mkt-banner-content .close {
-  margin-top: -17px;
+  margin: -17px 0 0 0;
   top: 50%;
+}
+.mkt-banner-content .close,
+.mkt-banner-content .close:hover {
+  background-color: transparent;
 }
 .mkt-banner-content span {
   display: inline-block;
@@ -32,6 +36,27 @@
   padding: 10px;
   text-decoration: none;
 }
+.mkt-banner-content a.spin {
+  color: transparent;
+  position: relative;
+}
+.mkt-banner-content a.spin:after {
+  -webkit-animation: 0.9s spin infinite steps(30);
+  animation: 0.9s spin infinite steps(30);
+  height: 30px;
+  margin: 0 auto;
+  background: url("../img/btn_spinner.png") no-repeat center;
+  width: 30px;
+  height: 18px;
+  margin: 2px 0;
+  background: url("../img/btn_spinner_18.png") no-repeat center;
+  width: 18px;
+  content: "";
+  display: block;
+  left: calc(50% - 9px);
+  position: absolute;
+  top: calc(50% - 11px);
+}
 .mkt-banner-firefox .mkt-banner-content {
   background: url("../img/logos/firefox-64.png") no-repeat;
   background-position: 0 50%;
@@ -45,17 +70,13 @@
 .mkt-banner-firefox a:hover {
   background-color: #4b4b4b;
 }
-.mkt-banner-firefox .close,
-.mkt-banner-firefox .close:hover {
-  background-color: transparent;
-}
 .mkt-banner-success {
   background: #64be3c;
 }
 .mkt-banner-success .mkt-banner-content {
   font-size: 15px;
   font-weight: 500;
-  padding: 0 10px;
+  padding: 0 40px;
 }
 .mkt-banner-success small {
   font-size: 15px;

--- a/dist/js/marketplace-elements.js
+++ b/dist/js/marketplace-elements.js
@@ -100,7 +100,7 @@
                         var closeButton = document.createElement('a');
                         closeButton.classList.add('close');
                         closeButton.href = '#';
-                        closeButton.textContent = gettext('Close');
+                        closeButton.textContent = '';
                         closeButton.title = gettext('Close');
                         closeButton.addEventListener('click', function (e) {
                             e.preventDefault();

--- a/marketplace-elements.js
+++ b/marketplace-elements.js
@@ -100,7 +100,7 @@
                         var closeButton = document.createElement('a');
                         closeButton.classList.add('close');
                         closeButton.href = '#';
-                        closeButton.textContent = gettext('Close');
+                        closeButton.textContent = '';
                         closeButton.title = gettext('Close');
                         closeButton.addEventListener('click', function (e) {
                             e.preventDefault();

--- a/marketplace-elements.styl
+++ b/marketplace-elements.styl
@@ -8,9 +8,9 @@
     background: $dark-gray;
     color: $white;
     display: block;
+    line-height: 1.3;
     overflow: hidden;
     position: relative;
-    line-height: 1.3;
 }
 
 .mkt-banner-content {
@@ -20,8 +20,13 @@
     text-align: center;
 
     .close {
-        margin-top: -17px;
+        margin: -17px 0 0 0;
         top: 50%;
+    }
+
+    .close,
+    .close:hover {
+        background-color: transparent;
     }
 
     span {
@@ -30,7 +35,6 @@
         padding: 0;
     }
 
-
     a {
         border-radius: 5px;
         color: #fff;
@@ -38,6 +42,20 @@
         margin: 10px;
         padding: 10px;
         text-decoration: none;
+
+        &.spin {
+            color: transparent;
+            position: relative;
+
+            &:after {
+                spinner('install');
+                content: "";
+                display: block;
+                left: unquote('calc(50% - 9px)');
+                position: absolute;
+                top: unquote('calc(50% - 11px)');
+            }
+        }
     }
 }
 
@@ -57,11 +75,6 @@
             background-color: darken($darker-gray, 10%);
         }
     }
-
-    .close,
-    .close:hover {
-        background-color: transparent;
-    }
 }
 
 .mkt-banner-success {
@@ -70,7 +83,7 @@
     .mkt-banner-content {
         font-size: 15px;
         font-weight: 500;
-        padding: 0 10px;
+        padding: 0 40px;
     }
 
     small {


### PR DESCRIPTION
Previously the styles were specific to the only banner that was using the close button (the incompatibility one), but there is going to be other banners using it, so make it generic.

Needed by mozilla/fireplace#823
