### PR TITLE
More banner themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The banner is used to show messages to users.
 
 | attribute | description |
 |-----------|-------------|
-| success   | Make it green |
+| theme     | Change the color scheme. May be any of the actions defined in [marketplace-frontend](https://github.com/mozilla/fireplace/blob/master/src/media/css/lib/colors.styl) or a light variant. Examples: `"success"` (default) or `"success-light"`. Additionally `"firefox"` may be specified for a gray banner with the Firefox logo. |
 | dismiss   | Configure dismissal. Values: `"on"` (default), `"off"`, `"remember"`. |
 
 Segmented

--- a/dist/css/marketplace-elements.css
+++ b/dist/css/marketplace-elements.css
@@ -15,32 +15,47 @@
   position: relative;
   text-align: center;
 }
-.mkt-banner-content .close {
-  margin: -17px 0 0 0;
+.mkt-banner-content .mkt-banner-close {
+  color: #fff;
+  cursor: pointer;
+  font-size: 40px;
+  font-weight: 100;
+  line-height: 0;
+  padding: 0 10px 0 0;
+  position: absolute;
+  right: 0;
   top: 50%;
 }
-.mkt-banner-content .close,
-.mkt-banner-content .close:hover {
-  background-color: transparent;
+.mkt-banner-content .mkt-banner-close:hover {
+  color: rgba(255,255,255,0.8);
 }
-.mkt-banner-content span {
+.mkt-banner-content .mkt-banner-close:active {
+  color: rgba(255,255,255,0.6);
+}
+.mkt-banner-content > span {
   display: inline-block;
   margin-top: 10px;
   padding: 0;
 }
 .mkt-banner-content a {
+  color: #fff;
+  font-weight: 100;
+  text-decoration: underline;
+}
+.mkt-banner-content > a {
   border-radius: 5px;
   color: #fff;
   display: inline-block;
+  font-weight: 500;
   margin: 10px;
   padding: 10px;
   text-decoration: none;
 }
-.mkt-banner-content a.spin {
+.mkt-banner-content > a.spin {
   color: transparent;
   position: relative;
 }
-.mkt-banner-content a.spin:after {
+.mkt-banner-content > a.spin:after {
   -webkit-animation: 0.9s spin infinite steps(30);
   animation: 0.9s spin infinite steps(30);
   height: 30px;
@@ -57,36 +72,99 @@
   position: absolute;
   top: calc(50% - 11px);
 }
-.mkt-banner-firefox .mkt-banner-content {
+.mkt-banner[theme="firefox"] .mkt-banner-content {
   background: url("../../img/logos/firefox-64.png") no-repeat;
   background-position: 0 50%;
   background-size: 64px 60px;
   min-height: 60px;
   padding: 0 40px 0 70px;
 }
-.mkt-banner-firefox a {
+.mkt-banner[theme="firefox"] .mkt-banner-content > a {
   background-color: #535353;
 }
-.mkt-banner-firefox a:hover {
+.mkt-banner[theme="firefox"] .mkt-banner-content > a:hover {
   background-color: #4b4b4b;
 }
-.mkt-banner-success {
-  background: #64be3c;
-}
-.mkt-banner-success .mkt-banner-content {
+.mkt-banner-content {
   font-size: 15px;
   font-weight: 500;
   padding: 0 40px;
 }
-.mkt-banner-success small {
+.mkt-banner-content small {
   font-size: 15px;
-  font-weight: 400;
+  font-weight: 500;
 }
-.mkt-banner-success a {
-  background-color: #118e36;
+.mkt-banner[theme=success] {
+  background: #64be3c;
 }
-.mkt-banner-success a:hover {
-  background-color: #0f8031;
+.mkt-banner[theme=success] .mkt-banner-content > a {
+  background-color: #4d8d32;
+}
+.mkt-banner[theme=success] .mkt-banner-content > a:hover {
+  background-color: #457f2d;
+}
+.mkt-banner[theme=success-light] {
+  background: #66d071;
+}
+.mkt-banner[theme=success-light] .mkt-banner-content > a {
+  background-color: #4d8d32;
+}
+.mkt-banner[theme=success-light] .mkt-banner-content > a:hover {
+  background-color: #457f2d;
+}
+.mkt-banner[theme=positive] {
+  background: #4cb1ff;
+}
+.mkt-banner[theme=positive] .mkt-banner-content > a {
+  background-color: #3d86bd;
+}
+.mkt-banner[theme=positive] .mkt-banner-content > a:hover {
+  background-color: #3779aa;
+}
+.mkt-banner[theme=positive-light] {
+  background: #42cafe;
+}
+.mkt-banner[theme=positive-light] .mkt-banner-content > a {
+  background-color: #3d86bd;
+}
+.mkt-banner[theme=positive-light] .mkt-banner-content > a:hover {
+  background-color: #3779aa;
+}
+.mkt-banner[theme=wait] {
+  background: #ffdc32;
+}
+.mkt-banner[theme=wait] .mkt-banner-content > a {
+  background-color: #bea434;
+}
+.mkt-banner[theme=wait] .mkt-banner-content > a:hover {
+  background-color: #ab942f;
+}
+.mkt-banner[theme=wait-light] {
+  background: #ffe26e;
+}
+.mkt-banner[theme=wait-light] .mkt-banner-content > a {
+  background-color: #bea434;
+}
+.mkt-banner[theme=wait-light] .mkt-banner-content > a:hover {
+  background-color: #ab942f;
+}
+.mkt-banner[theme=error] {
+  background: #f54b3c;
+}
+.mkt-banner[theme=error] .mkt-banner-content > a {
+  background-color: #b63932;
+}
+.mkt-banner[theme=error] .mkt-banner-content > a:hover {
+  background-color: #a4332d;
+}
+.mkt-banner[theme=error-light] {
+  background: #ff6c70;
+}
+.mkt-banner[theme=error-light] .mkt-banner-content > a {
+  background-color: #b63932;
+}
+.mkt-banner[theme=error-light] .mkt-banner-content > a:hover {
+  background-color: #a4332d;
 }
 .mkt-segmented-select {
   display: none;
@@ -218,7 +296,7 @@
   color: #fff;
   flex-grow: 1;
   font-size: 13px;
-  font-weight: 400;
+  font-weight: 500;
   height: 48px;
 }
 .mkt-prompt-btn-wrap button:hover {

--- a/dist/js/marketplace-elements.js
+++ b/dist/js/marketplace-elements.js
@@ -70,7 +70,6 @@
         prototype: Object.create(MktHTMLElement.prototype, {
             attributeClasses: {
                 value: {
-                    success: 'mkt-banner-success',
                     dismiss: null,
                 },
             },
@@ -79,9 +78,8 @@
                     MktHTMLElement.prototype.createdCallback.call(this);
                     this.classList.add('mkt-banner');
 
-                    // This is a Firefox banner if it isn't a success banner.
-                    if (!this.success) {
-                        this.classList.add('mkt-banner-firefox');
+                    if (!this.hasAttribute('theme')) {
+                        this.setAttribute('theme', 'success');
                     }
 
                     if (this.rememberDismissal && this.dismissed) {
@@ -101,10 +99,10 @@
                     content.innerHTML = html;
 
                     if (!this.undismissable) {
-                        var closeButton = document.createElement('a');
-                        closeButton.classList.add('close');
+                        var closeButton = document.createElement('div');
+                        closeButton.classList.add('mkt-banner-close');
                         closeButton.href = '#';
-                        closeButton.textContent = '';
+                        closeButton.innerHTML = '&times;';
                         closeButton.title = gettext('Close');
                         closeButton.addEventListener('click', function (e) {
                             e.preventDefault();

--- a/marketplace-elements.js
+++ b/marketplace-elements.js
@@ -70,7 +70,6 @@
         prototype: Object.create(MktHTMLElement.prototype, {
             attributeClasses: {
                 value: {
-                    success: 'mkt-banner-success',
                     dismiss: null,
                 },
             },
@@ -79,9 +78,8 @@
                     MktHTMLElement.prototype.createdCallback.call(this);
                     this.classList.add('mkt-banner');
 
-                    // This is a Firefox banner if it isn't a success banner.
-                    if (!this.success) {
-                        this.classList.add('mkt-banner-firefox');
+                    if (!this.hasAttribute('theme')) {
+                        this.setAttribute('theme', 'success');
                     }
 
                     if (this.rememberDismissal && this.dismissed) {
@@ -101,10 +99,10 @@
                     content.innerHTML = html;
 
                     if (!this.undismissable) {
-                        var closeButton = document.createElement('a');
-                        closeButton.classList.add('close');
+                        var closeButton = document.createElement('div');
+                        closeButton.classList.add('mkt-banner-close');
                         closeButton.href = '#';
-                        closeButton.textContent = '';
+                        closeButton.innerHTML = '&times;';
                         closeButton.title = gettext('Close');
                         closeButton.addEventListener('click', function (e) {
                             e.preventDefault();

--- a/marketplace-elements.styl
+++ b/marketplace-elements.styl
@@ -1,5 +1,8 @@
 @import 'bower_components/marketplace-frontend/src/media/css/lib';
 
+$font-narrow = 100;
+$font-bold = 500;
+
 .mkt-cloak {
     display: none;
 }
@@ -19,26 +22,43 @@
     position: relative;
     text-align: center;
 
-    .close {
-        margin: -17px 0 0 0;
+    .mkt-banner-close {
+        color: $greyscale-white;
+        cursor: pointer;
+        font-size: 40px;
+        font-weight: $font-narrow;
+        line-height: 0;
+        padding: 0 10px 0 0;
+        position: absolute;
+        right: 0;
         top: 50%;
     }
 
-    .close,
-    .close:hover {
-        background-color: transparent;
+    .mkt-banner-close:hover {
+        color: rgba($greyscale-white, 0.8);
     }
 
-    span {
+    .mkt-banner-close:active {
+        color: rgba($greyscale-white, 0.6);
+    }
+
+    > span {
         display: inline-block;
         margin-top: 10px;
         padding: 0;
     }
 
     a {
+        color: $white;
+        font-weight: $font-narrow;
+        text-decoration: underline;
+    }
+
+    > a {
         border-radius: 5px;
         color: #fff;
         display: inline-block;
+        font-weight: $font-bold;
         margin: 10px;
         padding: 10px;
         text-decoration: none;
@@ -59,43 +79,64 @@
     }
 }
 
-.mkt-banner-firefox {
+.mkt-banner[theme="firefox"] {
     .mkt-banner-content {
         background: url("../../img/logos/firefox-64.png") no-repeat;
         background-position: 0 50%;
         background-size: 64px 60px;
         min-height: 60px;
         padding: 0 40px 0 70px;
-    }
 
-    a {
-        background-color: $darker-gray;
+        > a {
+            background-color: $darker-gray;
 
-        &:hover {
-            background-color: darken($darker-gray, 10%);
+            &:hover {
+                background-color: darken($darker-gray, 10%);
+            }
         }
     }
 }
 
-.mkt-banner-success {
-    background: $action-success;
-
-    .mkt-banner-content {
-        font-size: 15px;
-        font-weight: 500;
-        padding: 0 40px;
-    }
+.mkt-banner-content {
+    font-size: 15px;
+    font-weight: $font-bold;
+    padding: 0 40px;
 
     small {
         font-size: 15px;
-        font-weight: 400;
+        font-weight: $font-bold;
+    }
+}
+
+$banner-colors = $action-success $action-positive $action-wait $action-error;
+$banner-colors-hover = $action-success-hover $action-positive-hover $action-wait-hover $action-error-hover;
+$banner-colors-tapped = $action-success-tapped $action-positive-tapped $action-wait-tapped $action-error-tapped;
+$banner-names = success positive "wait" error;
+for $i in (0..3) {
+    $banner-color = $banner-colors[$i];
+    $banner-color-hover = $banner-colors-hover[$i];
+    $banner-color-tapped = $banner-colors-tapped[$i];
+    $banner-name = $banner-names[$i];
+
+    .mkt-banner[theme={$banner-name}] {
+        background: $banner-color;
+        .mkt-banner-content > a {
+            background-color: $banner-color-tapped;
+
+            &:hover {
+                background-color: darken($banner-color-tapped, 10%);
+            }
+        }
     }
 
-    a {
-        background-color: $dark-green;
+    .mkt-banner[theme={$banner-name}-light] {
+        background: $banner-color-hover;
+        .mkt-banner-content > a {
+            background-color: $banner-color-tapped;
 
-        &:hover {
-            background-color: darken($dark-green, 10%);
+            &:hover {
+                background-color: darken($banner-color-tapped, 10%);
+            }
         }
     }
 }
@@ -218,7 +259,7 @@
         width: 100%;
     }
     h3 {
-        font-weight: 500;
+        font-weight: $font-bold;
         margin-top: 20px;
     }
     p {
@@ -252,7 +293,7 @@
     color: $white;
     flex-grow: 1;
     font-size: 13px;
-    font-weight: 400;
+    font-weight: $font-bold;
     height: 48px;
 
     &:hover {


### PR DESCRIPTION
`<mkt-banner success>` becomes `<mkt-banner theme="success">`

Add all the themes, also add support for a light version.

`<mkt-banner theme="success-light">My banner</mkt-banner>`

![screenshot 2015-01-10 20 53 18](https://cloud.githubusercontent.com/assets/211578/5694154/ab994bb8-990a-11e4-98b8-5140fcfbd3de.png)

