### PR TITLE
Support dismissal of <mkt-banner> per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The banner is used to show messages to users.
 | attribute | description |
 |-----------|-------------|
 | theme     | Change the color scheme. May be any of the actions defined in [marketplace-frontend](https://github.com/mozilla/fireplace/blob/master/src/media/css/lib/colors.styl) or a light variant. Examples: `"success"` (default) or `"success-light"`. Additionally `"firefox"` may be specified for a gray banner with the Firefox logo. |
-| dismiss   | Configure dismissal. Values: `"on"` (default), `"off"`, `"remember"`. |
+| dismiss   | Configure dismissal. Values: `"on"` (default), `"off"`, `"remember"`, `"session"`. |
 
 Segmented
 ---------

--- a/marketplace-elements.js
+++ b/marketplace-elements.js
@@ -19,6 +19,17 @@
         };
     })();
 
+    function makeStorage(storage) {
+        return {
+            getItem: function(key) {
+                return JSON.parse(storage.getItem(key));
+            },
+            setItem: function(key, value) {
+                storage.setItem(key, JSON.stringify(value));
+            },
+        };
+    }
+
     // Mock gettext if it doesn't exist globally.
     var gettext = window.gettext || function (str) { return str; };
 
@@ -130,17 +141,26 @@
             },
             rememberDismissal: {
                 get: function () {
-                    return this.dismiss === 'remember';
+                    return this.dismiss === 'remember' ||
+                           this.dismiss === 'session';
                 },
             },
             storage: {
                 get: function () {
-                    return require('storage');
+                    if (this.dismiss === 'remember') {
+                        return makeStorage(localStorage);
+                    } else if (this.dismiss === 'session') {
+                        return makeStorage(sessionStorage);
+                    }
                 },
             },
             storageKey: {
                 get: function () {
-                    return 'hide_' + this.id.replace(/-/g, '_');
+                    if (this.hasAttribute('name')) {
+                        return 'mkt-banner-hide-' + this.getAttribute('name');
+                    } else {
+                        return 'hide_' + this.id.replace(/-/g, '_');
+                    }
                 },
             },
             undismissable: {


### PR DESCRIPTION
Adds support for remembering the dismissal of a banner in `sessionStorage`. Refreshes won't bring it back but a new tab will.