### PR TITLE
Use data-set-tab to set mkt-tab[current]

### DIFF
--- a/marketplace-elements.js
+++ b/marketplace-elements.js
@@ -316,6 +316,17 @@
                     root.tabs = tabs;
                     var current = root.getAttribute('current');
 
+                    // If a child element with a `data-set-tab` attribute is
+                    // clicked then set the tab and prevent the event's
+                    // default behaviour.
+                    root.addEventListener('click', function(e) {
+                        var targetTab = e.target.getAttribute('data-set-tab');
+                        if (targetTab) {
+                            e.preventDefault();
+                            root.setAttribute('current', targetTab);
+                        }
+                    });
+
                     root.classList.add('mkt-tabs');
                     forEach(tabs, function(tab) {
                         tab.classList.add('mkt-tab');


### PR DESCRIPTION
This allows an element to set the current tab through markup.

```html
<mkt-tabs current="one">
  <section name="one">
    <h1>One!</h1>
    <button data-set-tab="two">Next</button>
  </section>
  <section name="two">
    <h1>Two!</h1>
    <button data-set-tab="one">Previous</button>
    <button data-set-tab="three">Next</button>
  </section>
  <section name="three">
    <h1>Three!</h1>
    <button data-set-tab="two">Previous</button>
  </section>
</mkt-tabs>
```

![mkt-tabs-data-set-tab mov](https://cloud.githubusercontent.com/assets/211578/6612187/7eeb42d2-c845-11e4-95f8-2396ed49f1e7.gif)
