### PR TITLE
Fix mkt-banner not auto-dismissing (bug 1172707)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+branches:
+  only:
+  - master
+notifications:
+  email: false
+language: node_js
+node_js:
+- '0.10'
+before_script:
+- npm install
+- bower install
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+script:
+- karma start --single-run
+cache:
+  directories:
+  - node_modules
+  - bower_components

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,67 @@
+// Karma configuration
+// Generated on Tue Jun 09 2015 21:41:12 GMT-0500 (CDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'chai'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'bower_components/document-register-element/build/document-register-element.js',
+      'marketplace-elements.js',
+      'tests/test-*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['mocha'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Firefox'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/marketplace-elements.js
+++ b/marketplace-elements.js
@@ -98,7 +98,7 @@
                     }
 
                     if (this.rememberDismissal && this.dismissed) {
-                        this.dismissBanner();
+                        this.dismissBanner({immediate: true});
                     }
 
                     // Format the initial HTML.
@@ -135,17 +135,26 @@
                 },
             },
             dismissBanner: {
-                value: function () {
+                value: function (opts) {
+                    // opts.immediate (bool)
+                    //     dismiss the banner without a transition.
+                    opts = opts || {};
                     if (this.rememberDismissal) {
                         this.storage.setItem(this.storageKey, true);
                     }
-                    this.addEventListener('transitionend', function() {
+                    var removeBanner = function() {
                         // This could get called more than once.
                         if (this.parentNode) {
                             this.parentNode.removeChild(this);
                         }
-                    }.bind(this));
-                    this.style.maxHeight = 0;
+                    }.bind(this);
+                    if (opts.immediate) {
+                        removeBanner();
+                    } else {
+                        setTimeout(removeBanner, 500);
+                        this.addEventListener('transitionend', removeBanner);
+                        this.style.maxHeight = 0;
+                    }
                 },
             },
             rememberDismissal: {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
     "npm": ">= 1.1.x"
   },
   "dependencies": {
+    "bower": "^1.4.1",
+    "chai": "^3.0.0",
+    "karma": "^0.12.36",
+    "karma-chai": "^0.1.0",
+    "karma-firefox-launcher": "^0.1.6",
+    "karma-mocha": "^0.1.10",
+    "karma-mocha-reporter": "^1.0.2",
+    "mocha": "^2.2.5",
     "stylus": "0.32.x"
   }
 }

--- a/tests/test-mkt-banner.js
+++ b/tests/test-mkt-banner.js
@@ -1,0 +1,58 @@
+(function() {
+    afterEach(function() {
+        document.body.innerHTML = '';
+        localStorage.clear();
+    });
+
+    describe('mkt-banner', function() {
+        it('can be hidden', function(done) {
+            function makeBanner() {
+                var div = document.createElement('div');
+                div.style.display = 'none';
+                div.innerHTML = '<mkt-banner>Heya</mkt-banner>';
+                document.body.appendChild(div);
+            }
+
+            makeBanner();
+            assert(document.querySelector('mkt-banner'), 'element exists');
+            setTimeout(function() {
+                document.querySelector('.mkt-banner-close')
+                        .dispatchEvent(new Event('click'));
+
+                setTimeout(function() {
+                    assert(!document.querySelector('mkt-banner'),
+                           'element is removed');
+                    done();
+                }, 500);
+            }, 1);
+        });
+
+        it('can be hidden permanently', function(done) {
+            function makeBanner() {
+                var div = document.createElement('div');
+                div.style.display = 'none';
+                div.innerHTML = '<mkt-banner name="yo" dismiss="remember">Heya</mkt-banner>';
+                document.body.appendChild(div);
+            }
+
+            makeBanner();
+            assert(document.querySelector('mkt-banner'), 'element exists');
+            setTimeout(function() {
+                document.querySelector('.mkt-banner-close')
+                        .dispatchEvent(new Event('click'));
+
+                setTimeout(function() {
+                    assert(!document.querySelector('mkt-banner'),
+                           'element is removed');
+
+                    makeBanner();
+                    setTimeout(function() {
+                        assert(!document.querySelector('mkt-banner'),
+                               'element is not added');
+                        done();
+                    }, 1);
+                }, 500);
+            }, 1);
+        });
+    });
+})();


### PR DESCRIPTION
This adds karma, mocha and chai.

There was a regression when the close animation was added that caused
the mkt-banner to not be dismissed when it wasn't visble since the
transitionend event would not fire. The banner will now always be
dismissed after 500ms and it will be immediately dismissed when it is
first created if it has been dismissed and dismiss="remember" or
dismiss="session".