### PR TITLE
show submit on form:valid for mkt-prompt (bug 1189388)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,5 +24,5 @@
     "amd"
   ],
   "name": "marketplace-elements",
-  "version": "0.6.1"
+  "version": "0.6.2"
 }

--- a/marketplace-elements.styl
+++ b/marketplace-elements.styl
@@ -316,11 +316,7 @@ for $i in (0..3) {
 }
 
 .mkt-prompt form:invalid [type="submit"] {
-    background: $greyscale-grey;
-
-    &:hover {
-        cursor: default;
-    }
+    display: none;
 }
 
 .mkt-prompt[data-modal] {


### PR DESCRIPTION
For the record I really dislike hiding the submit button until the form is valid:

![](http://i.imgur.com/KICIH3u.png)

![](http://i.imgur.com/Y9TII0v.png)