### PR TITLE
Fix for closing modal on esc press (bug 1165656)

### DIFF
--- a/marketplace-elements.js
+++ b/marketplace-elements.js
@@ -415,6 +415,15 @@
                             this.dispatchEvent(MktEvent('mkt-prompt-cancel'));
                             root.dismissModal();
                         });
+
+                        // Closes modal on esc key press.
+                        document.addEventListener('keyup', function(e) {
+                            var key = e.which || e.keyCode;
+                            if (key === 27) {
+                                this.dispatchEvent(MktEvent('mkt-prompt-cancel'));
+                                root.dismissModal();
+                            }
+                        });
                     }
 
                     // Submit button triggers event with data.


### PR DESCRIPTION
The popup modal for app reviews would not close by esc key.
