### PR TITLE
Fix a bug where banners might not appear until a resize

### DIFF
--- a/marketplace-elements.js
+++ b/marketplace-elements.js
@@ -126,7 +126,9 @@
 
                     this.innerHTML = '';
                     this.appendChild(content);
-                    this.setMinHeight();
+                    setTimeout(function() {
+                        this.setMinHeight();
+                    }.bind(this), 20);
                 },
             },
             dismissed: {


### PR DESCRIPTION
r? @ngokevin 

The height of the element might be `0` until it gets painted so we need to wait for a paint to happen before checking the height.